### PR TITLE
Remove warnings about unique keys for list

### DIFF
--- a/src/app/editor/components/EditElement.tsx
+++ b/src/app/editor/components/EditElement.tsx
@@ -114,8 +114,7 @@ export function EditElement({
   }
 
   // FORM QUESTIONS
-  const htmlElements = []
-  htmlElements.push(
+  const htmlElements = (
     <form onSubmit={handleSubmit(saveEdits)}>
       <div>
         <label className="form-control w-full max-w-xs">

--- a/src/app/editor/components/EditStage.tsx
+++ b/src/app/editor/components/EditStage.tsx
@@ -96,8 +96,7 @@ export function EditStage({
 
   // ----------- Form Questions -----------------
 
-  const htmlElements = []
-  htmlElements.push(
+  const htmlElements = (
     <form>
       {' '}
       {/* onSubmit={handleSubmit(saveEdits)}> */}


### PR DESCRIPTION
Make htmlElements one value, instead of an array

Closes #75 