### PR TITLE
Implement collapsible rows in code editor

### DIFF
--- a/cypress/e2e/test.cy.ts
+++ b/cypress/e2e/test.cy.ts
@@ -1,5 +1,4 @@
 // npm run cypress:open
-
 describe('test spec', () => {
   it('passes', () => {
 
@@ -11,7 +10,11 @@ describe('test spec', () => {
     cy.viewport(2000, 1000, { log: false });
 
     cy.visit('http://localhost:3000/editor')
-    cy.get('[data-cy="code-editor"]').clear().type(yamltreatment)
+    cy.get('[data-cy="code-editor"]').get('.monaco-editor').type('{ctrl+a}{del}', { release: false }) // equivalent to clear() in cypress
+    cy.get('[data-cy="code-editor"]').get('.monaco-editor').type(yamltreatment)
+    //this fails because getting monaco-editor will include line numbers, but the yamltreatment variable does not
+    // also monaco-editor will remove line breaks, but yamltreatment will have the line breaks
+    //cy.get('[data-cy="code-editor"]').get('.monaco-editor').should('include.text', yamltreatment)
     cy.get('[data-cy="yaml-save"]').click()
 
     // create first stage
@@ -89,18 +92,19 @@ describe('test spec', () => {
     cy.get('[data-cy="stage-0"]').should("not.contain", "Element 2")
 
     // add fourth element to second stage via code editor
-    cy.get('[data-cy="code-editor"]').type("      - name: Element 4\n  type: prompt\nfile: file/address")
+    cy.get('[data-cy="code-editor"]').get('.monaco-editor').type("      - name: Element 4\n  type: prompt\nfile: file/address")
     cy.get('[data-cy="yaml-save"]').click()
 
-    cy.get('[data-cy="code-editor"]').contains("- name: Element 4").should("be.visible")
+    cy.get('[data-cy="code-editor"]').get('.monaco-editor').contains("- name: Element 4").should("be.visible")
     cy.get('[data-cy="element-1-1"]').contains("prompt").should("be.visible")
     cy.get('[data-cy="element-1-1"]').contains("Element 4").should("be.visible")
 
     // add third stage via code editor
-    cy.get('[data-cy="code-editor"]').type("\n{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}- name: Stage 3\n  duration: 300\nelements: []")
+    cy.get('[data-cy="code-editor"]').get('.monaco-editor').type("{moveToEnd}{enter}", { release: false })
+    cy.get('[data-cy="code-editor"]').get('.monaco-editor').type("{home}  - name: Stage 3\n  duration: 300\nelements: []")
     cy.get('[data-cy="yaml-save"]').click()
 
-    cy.get('[data-cy="code-editor"]').contains("- name: Stage 3").should("be.visible")
+    cy.get('[data-cy="code-editor"]').get('.monaco-editor').contains("- name: Stage 3").should("be.visible")
     cy.get('[data-cy="stage-2"]').contains("Stage 3").should("be.visible")
 
     // edit first stage

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@empirica/core": "^1.11.0",
         "@hello-pangea/dnd": "^16.6.0",
         "@hookform/resolvers": "^3.6.0",
+        "@monaco-editor/react": "^4.6.0",
         "@uiw/react-textarea-code-editor": "^2.1.9",
         "@watts-lab/surveys": "^1.13.4",
         "next": "^13.5.6",
@@ -443,6 +444,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -6897,6 +6922,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8909,6 +8940,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@empirica/core": "^1.11.0",
     "@hello-pangea/dnd": "^16.6.0",
     "@hookform/resolvers": "^3.6.0",
+    "@monaco-editor/react": "^4.6.0",
     "@uiw/react-textarea-code-editor": "^2.1.9",
     "@watts-lab/surveys": "^1.13.4",
     "next": "^13.5.6",

--- a/src/app/editor/components/CodeEditor.tsx
+++ b/src/app/editor/components/CodeEditor.tsx
@@ -1,5 +1,5 @@
 'use client'
-import YamlEditor from '@uiw/react-textarea-code-editor'
+import Editor from '@monaco-editor/react'
 import { useState, useEffect, useMemo } from 'react'
 import { parse } from 'yaml'
 import { stringify } from 'yaml'
@@ -103,9 +103,9 @@ export default function CodeEditor() {
     }
   }, [defaultTreatment])
 
-  function handleChange(evn: any) {
-    let entry = evn.target.value
-    setCode(entry)
+  function handleChange(newValue: any) {
+    console.log('newValue from editor OnChange: ', newValue)
+    setCode(newValue)
   }
 
   function handleSave(e: any) {
@@ -125,14 +125,18 @@ export default function CodeEditor() {
       <div
         style={{ height: '95vh', overflow: 'auto', backgroundColor: '#F0F2F6' }}
       >
-        <YamlEditor
+        <Editor
           data-cy="code-editor"
           value={code}
           language="yaml"
-          placeholder={
+          options={{
+            wordWrap: 'on',
+            showFoldingControls: 'always',
+          }}
+          defaulValue={
             'Please enter treatment configuration. Do not refresh the page before saving.'
           }
-          onChange={(env) => handleChange(env)}
+          onChange={(newValue) => handleChange(newValue)}
           padding={5}
           style={{
             fontSize: 12,

--- a/src/app/editor/components/CodeEditor.tsx
+++ b/src/app/editor/components/CodeEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Editor from '@monaco-editor/react'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { parse } from 'yaml'
 import { stringify } from 'yaml'
 
@@ -132,18 +132,13 @@ export default function CodeEditor() {
           options={{
             wordWrap: 'on',
             showFoldingControls: 'always',
+            wrappingIndent: 'same',
+            minimap: {
+              enabled: true,
+            },
+            automaticLayout: true,
           }}
-          defaulValue={
-            'Please enter treatment configuration. Do not refresh the page before saving.'
-          }
           onChange={(newValue) => handleChange(newValue)}
-          padding={5}
-          style={{
-            fontSize: 12,
-            fontFamily:
-              'ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace',
-            backgroundColor: '#F0F2F6',
-          }}
         />
       </div>
       <div style={{ backgroundColor: '#F0F2F6' }}>

--- a/src/app/editor/components/CodeEditor.tsx
+++ b/src/app/editor/components/CodeEditor.tsx
@@ -124,9 +124,9 @@ export default function CodeEditor() {
     <div>
       <div
         style={{ height: '95vh', overflow: 'auto', backgroundColor: '#F0F2F6' }}
+        data-cy="code-editor"
       >
         <Editor
-          data-cy="code-editor"
           value={code}
           language="yaml"
           options={{

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -57,7 +57,7 @@ export default function EditorPage({}) {
 
         <DraggableSplitter dir="vertical" {...codeSeparatorProps} />
 
-        <div id="rightColumn" className="grow">
+        <div id="rightColumn" className="flex-1 min-w-[200px] overflow-auto">
           <CodeEditor />
         </div>
       </div>


### PR DESCRIPTION
Closes #82 
- Replaces code editor component with Monaco. [Monaco](https://www.npmjs.com/package/@monaco-editor/react#editor), customization [options here](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IEditorOptions.html#showFoldingControls).
- Monaco is what VSCode is built on, so it looks quite good.
- onChange passes the new text value within the editor, which is simple to deal with, especially in comparison to CodeMirror
- See more here: https://github.com/Watts-Lab/researcher-portal/issues/82