### PR TITLE
Drag and Drop to Reorder Stages and Elements within Timeline

### DIFF
--- a/cypress/e2e/reorder.cy.ts
+++ b/cypress/e2e/reorder.cy.ts
@@ -1,0 +1,142 @@
+// npm run cypress:open
+
+describe('timeline drag and drop', () => {
+    beforeEach(() => {
+        // initial yaml treatment file
+        let yamltreatment = "name: drag_and_drop_test\nplayerCount: 1\ngameStages: []";
+
+        cy.viewport(2000, 1000, { log: false });
+        cy.visit('http://localhost:3000/editor');
+        cy.get('[data-cy="code-editor"]').clear().type(yamltreatment);
+        cy.get('[data-cy="yaml-save"]').click();
+
+        // add first stage
+        cy.get('[data-cy="add-stage-button"]').click();
+        cy.get('[data-cy="edit-stage-name-new"]').type("Stage 1");
+        cy.get('[data-cy="edit-stage-duration-new"]').type("{backspace}300");
+        cy.get('[data-cy="edit-stage-save-new"]').click();
+
+        // add element 1 in stage 1
+        cy.get('[data-cy="add-element-button-0"]').click();
+        cy.get('[data-cy="edit-element-name-0-new"]').type("Element 1");
+        cy.get('[data-cy="edit-element-type-0-new"]').select("Prompt");
+        cy.get('[data-cy="edit-element-file-0-new"]').type("projects/example/preDiscussionInstructions.md");
+        cy.get('[data-cy="edit-element-save-0-new"]').click();
+
+        // add element 2 in stage 1
+        cy.get('[data-cy="add-element-button-0"]').click();
+        cy.get('[data-cy="edit-element-name-0-new"]').type("Element 2");
+        cy.get('[data-cy="edit-element-type-0-new"]').select("Survey");
+        cy.get('[data-cy="edit-element-surveyName-0-new"]').select("TIPI");
+        cy.get('[data-cy="edit-element-save-0-new"]').click();
+
+        // add second stage
+        cy.get('[data-cy="add-stage-button"]').click();
+        cy.get('[data-cy="edit-stage-name-new"]').type("Stage 2");
+        cy.get('[data-cy="edit-stage-duration-new"]').type("{backspace}200");
+        cy.get('[data-cy="edit-stage-save-new"]').click();
+
+        cy.get('[data-cy="stage-0"]').contains("Stage 1").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("Stage 2").should("be.visible");
+        cy.get('[data-cy="element-0-0"]').contains("Element 1").should("be.visible");
+        cy.get('[data-cy="element-0-1"]').contains("Element 2").should("be.visible");
+    });
+
+    it('allows reordering of elements within stage', () => {
+        // verify initial order
+        cy.get('[data-cy="element-0-0"]').contains("Element 1").should("be.visible");
+        cy.get('[data-cy="element-0-1"]').contains("Element 2").should("be.visible");
+        cy.get('[data-cy^="element-0-"]').should('have.length', 2);
+
+        // swap first element with second element
+        cy.get('[data-cy="element-0-0"]')
+            .focus()
+            .type(" ") // space bar selects item to move
+            .type("{downArrow}") // move element down one
+            .type(" "); // stop moving item
+
+        cy.wait(1000);
+
+        // verify new order
+        cy.get('[data-cy="element-0-0"]').contains("Element 2").should("be.visible");
+        cy.get('[data-cy="element-0-1"]').contains("Element 1").should("be.visible");
+        cy.get('[data-cy^="element-0-"]').should('have.length', 2);
+    })
+
+    it('allows reodering of stages', () => {
+        // verify initial order
+        cy.get('[data-cy="stage-0"]').contains("Stage 1").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("Stage 2").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+
+        // swap first stage with second stage
+        cy.get('[data-cy="stage-0"]')
+            .focus()
+            .type(" ")
+            .type("{rightArrow}") // move stage 1 to the right
+            .type(" ");
+
+        cy.wait(1000);
+
+        // verify new order
+        cy.get('[data-cy="stage-0"]').contains("Stage 2").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("Stage 1").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+    })
+
+    it('rejects dragging elements to invalid spots', () => {
+        // verify initial order
+        cy.get('[data-cy="element-0-0"]').contains("Element 1").should("be.visible");
+        cy.get('[data-cy="element-0-1"]').contains("Element 2").should("be.visible");
+        cy.get('[data-cy^="element-0-"]').should('have.length', 2);
+
+        // try moving first element from stage 1 to stage 2
+        cy.get('[data-cy="element-0-0"]')
+            .focus()
+            .type(" ")
+            .type("{rightArrow}")
+            .type(" ");
+
+        cy.wait(1000);
+
+        // verify that order remains the same
+        cy.get('[data-cy="element-0-0"]').contains("Element 1").should("be.visible");
+        cy.get('[data-cy="element-0-1"]').contains("Element 2").should("be.visible");
+        cy.get('[data-cy^="element-0-"]').should('have.length', 2);
+
+        // try moving second element outside of stage 1
+        cy.get('[data-cy="element-0-1"]')
+            .focus()
+            .type(" ")
+            .type("{rightArrow}")
+            .type(" ");
+
+        cy.wait(1000);
+
+        // verify that order remains the same
+        cy.get('[data-cy="element-0-0"]').contains("Element 1").should("be.visible");
+        cy.get('[data-cy="element-0-1"]').contains("Element 2").should("be.visible");
+        cy.get('[data-cy^="element-0-"]').should('have.length', 2);
+    })
+
+    it('rejects dragging stages outside of timeline', () => {
+        // verify initial order
+        cy.get('[data-cy="stage-0"]').contains("Stage 1").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("Stage 2").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+
+        // try dragging stage outside of timeline 
+        cy.get('[data-cy="stage-0"]')
+            .focus()
+            .type(" ")
+            .type("{upArrow}")
+            .type(" ");
+
+        cy.wait(1000);
+
+        // verify that order remains the same
+        cy.get('[data-cy="stage-0"]').contains("Stage 1").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("Stage 2").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+    })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "researcher-portal",
       "version": "0.1.0",
       "dependencies": {
-        "@empirica/core": "^1.11.0",
+        "@empirica/core": "^1.11.6",
         "@hello-pangea/dnd": "^17.0.0",
         "@hookform/resolvers": "^3.6.0",
         "@uiw/react-textarea-code-editor": "^2.1.9",
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@empirica/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@empirica/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-za/RAcZaMkSemghg3ekjVnUEzXlkyfMOGSfwFcb9l94xa9c54HCVtI1KIsNO+Q7bZjjXVVT7lKYQnzqlSXkbhw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@empirica/core/-/core-1.11.6.tgz",
+      "integrity": "sha512-nAL2kyiC5fzdY92dGgb9RuVeAeNEYCXGrMJAbX8JEWgn8VmphYZphF0ctSEsOXcPb8gRnLJ93FolJfWzohZs9g==",
       "dependencies": {
         "@empirica/tajriba": "1.7.0",
         "@swc/helpers": "0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@empirica/core": "^1.11.0",
-        "@hello-pangea/dnd": "^16.6.0",
+        "@hello-pangea/dnd": "^17.0.0",
         "@hookform/resolvers": "^3.6.0",
         "@uiw/react-textarea-code-editor": "^2.1.9",
         "@watts-lab/surveys": "^1.13.4",
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -247,21 +247,21 @@
       }
     },
     "node_modules/@hello-pangea/dnd": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-16.6.0.tgz",
-      "integrity": "sha512-vfZ4GydqbtUPXSLfAvKvXQ6xwRzIjUSjVU0Sx+70VOhc2xx6CdmJXJ8YhH70RpbTUGjxctslQTHul9sIOxCfFQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-17.0.0.tgz",
+      "integrity": "sha512-LDDPOix/5N0j5QZxubiW9T0M0+1PR0rTDWeZF5pu1Tz91UQnuVK4qQ/EjY83Qm2QeX0eM8qDXANfDh3VVqtR4Q==",
       "dependencies": {
-        "@babel/runtime": "^7.24.1",
+        "@babel/runtime": "^7.25.6",
         "css-box-model": "^1.2.1",
         "memoize-one": "^6.0.0",
         "raf-schd": "^4.0.3",
-        "react-redux": "^8.1.3",
-        "redux": "^4.2.1",
+        "react-redux": "^9.1.2",
+        "redux": "^5.0.1",
         "use-memo-one": "^1.1.3"
       },
       "peerDependencies": {
-        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -1110,15 +1110,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1182,7 +1173,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4786,14 +4777,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/html-url-attributes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
@@ -7987,47 +7970,26 @@
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/react-redux": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
-      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+      "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
       "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
         "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
         "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4 || ^5.0.0-beta.0"
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "redux": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
           "optional": true
         },
         "redux": {
           "optional": true
         }
       }
-    },
-    "node_modules/react-redux/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-resizable-layout": {
       "version": "0.7.2",
@@ -8108,12 +8070,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@empirica/core": "^1.11.0",
-    "@hello-pangea/dnd": "^16.6.0",
+    "@hello-pangea/dnd": "^17.0.0",
     "@hookform/resolvers": "^3.6.0",
     "@uiw/react-textarea-code-editor": "^2.1.9",
     "@watts-lab/surveys": "^1.13.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "patch": "cp patchedPlayer.d.ts ./node_modules/@empirica/core/dist/player-classic-react.d.ts"
   },
   "dependencies": {
-    "@empirica/core": "^1.11.0",
+    "@empirica/core": "^1.11.6",
     "@hello-pangea/dnd": "^17.0.0",
     "@hookform/resolvers": "^3.6.0",
     "@uiw/react-textarea-code-editor": "^2.1.9",

--- a/src/app/editor/components/ElementCard.tsx
+++ b/src/app/editor/components/ElementCard.tsx
@@ -34,6 +34,7 @@ export function ElementCard({
       className="card bg-base-200 shadow-md min-h-12 min-w-[10px] justify-center px-5"
       style={{ left: startTime * scale, width: scale * (endTime - startTime) }}
       data-cy={'element-' + stageIndex + '-' + elementIndex}
+      tabIndex={0}
     >
       <div>
         {Object.keys(element).map((key) => (

--- a/src/app/editor/components/StageCard.tsx
+++ b/src/app/editor/components/StageCard.tsx
@@ -110,6 +110,7 @@ export function StageCard({
       style={{ width: scale * duration }}
       onClick={handleStageClick}
       data-cy={'stage-' + stageIndex}
+      tabIndex={0}
     >
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <h3 className="mx-3 my-2">{title}</h3>

--- a/src/app/editor/components/Timeline.tsx
+++ b/src/app/editor/components/Timeline.tsx
@@ -9,6 +9,7 @@ import { Modal } from './Modal'
 import { EditStage } from './EditStage'
 import { TreatmentType } from '../../../../deliberation-empirica/server/src/preFlight/validateTreatmentFile'
 import { StageContext } from '@/editor/stageContext'
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
 
 export default function Timeline({
   setRenderPanelStage,
@@ -46,6 +47,25 @@ export default function Timeline({
     return null
   }
 
+  // drag and drop handler
+  function onDragEnd(result: any) {
+    const { destination, source } = result
+    if (!destination) {
+      return
+    }
+
+    const sourceIndex = source.index
+    const destIndex = destination.index
+    const updatedStages = Array.from(treatment.gameStages)
+    const [removed] = updatedStages.splice(sourceIndex, 1)
+    updatedStages.splice(destIndex, 0, removed)
+
+    // update treatment
+    const updatedTreatment = JSON.parse(JSON.stringify(treatment)) // deep copy
+    updatedTreatment.gameStages = updatedStages
+    editTreatment(updatedTreatment)
+  }
+
   //const parsedCode = "";
 
   // TODO: add a page before this that lets the researcher select what treatment to work on
@@ -66,21 +86,47 @@ export default function Timeline({
         className="grow min-h-10 bg-slate-600 p-2 overflow-y-auto overflow-x-auto"
       >
         <div className="flex flex-row flex-nowrap overflow-x-auto gap-x-1 overflow-y-auto">
-          {treatment &&
-            treatment?.gameStages?.map((stage: any, index: any) => (
-              <StageCard
-                key={stage.name}
-                title={stage.name}
-                elements={stage.elements}
-                duration={stage.duration}
-                scale={scale}
-                treatment={treatment}
-                editTreatment={editTreatment}
-                sequence={'gameStage'}
-                stageIndex={index}
-                setRenderPanelStage={setRenderPanelStage}
-              />
-            ))}
+          <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable droppableId="droppable-timeline" direction="horizontal">
+              {(provided) => (
+                <div
+                  {...provided.droppableProps}
+                  ref={provided.innerRef}
+                  className="flex flex-row"
+                >
+                  {treatment?.gameStages?.map((stage: any, index: any) => (
+                    <Draggable
+                      key={stage.name}
+                      draggableId={`stage-${index}`}
+                      index={index}
+                    >
+                      {(provided) => (
+                        <div
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                        >
+                          <StageCard
+                            title={stage.name}
+                            elements={stage.elements}
+                            duration={stage.duration}
+                            scale={scale}
+                            treatment={treatment}
+                            editTreatment={editTreatment}
+                            sequence={'gameStage'}
+                            stageIndex={index}
+                            setRenderPanelStage={setRenderPanelStage}
+                          />
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+
           <div className="card bg-slate-300 w-12 m-1 opacity-50 flex items-center">
             <button
               data-cy="add-stage-button"

--- a/src/app/editor/components/Timeline.tsx
+++ b/src/app/editor/components/Timeline.tsx
@@ -92,7 +92,7 @@ export default function Timeline({
                 <div
                   {...provided.droppableProps}
                   ref={provided.innerRef}
-                  className="flex flex-row"
+                  className="flex flex-row gap-x-1"
                 >
                   {treatment?.gameStages?.map((stage: any, index: any) => (
                     <Draggable


### PR DESCRIPTION
## Description
This PR adds drag and drop functionality as outlined in issue #3. It uses the same drag and drop library used in deliberation empirica (hello-pangea/dnd). Users can now reorder stages and elements within their respective stages while updating the treatment file in real-time.

Closes #3 

 ## Changes
- package.json: updates the version for hello-pangea/dnd library
- Timeline.tsx: scopes DragDropContext for individual stages and wraps each stage in a draggable component
- StageCard.tsx: wraps each element card in a draggable component
- New e2e tests: tests 1) moving elements within stage, 2) moving stages in timeline, 3) moving elements outside of valid stage, 4) moving stages outside of timeline

## Checks
 - [x] Ability to drag and drop stages to reorder
 - [x] Ability to drag and drop elements to reorder
 - [x] Treatment file is updated after each reorder
 - [x] All tests pass
 - [x] Add new tests, as needed