### PR TITLE
Selectable Treatments and Stages/Elements

### DIFF
--- a/@empirica-mocks/core/mocks.js
+++ b/@empirica-mocks/core/mocks.js
@@ -93,21 +93,25 @@ export function useStage() {
       //const treatmentString = localStorage.getItem("treatment");
       //const treatment = JSON.parse(treatmentString);
       if (varName === "elements") {
-        var elements = treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.elements
-        elements =  elements.flatMap((element) => {
-          if (element.template) {
-            return templatesMap.get(element.template);
-          }
-          return [element];
-        });
+        let elements = treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.elements;
+        if (Array.isArray(elements)) {
+          elements = elements.flatMap((element) => {
+            if (element.template) {
+              return templatesMap.get(element.template);
+            }
+            return [element];
+          });
+        } else {
+          elements = [];
+        }
         console.log("revised elements", elements)
         return elements;
       } else if (varName === "discussion") {
-        return treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.discussion
+        return treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.discussion;
       } else if (varName === "name") {
-        return treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.name
+        return treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.name;
       } else if (varName === "index") {
-        return currentStageIndex
+        return currentStageIndex;
       }
     },
     

--- a/@empirica-mocks/core/mocks.js
+++ b/@empirica-mocks/core/mocks.js
@@ -79,6 +79,8 @@ export function useStage() {
     setTreatment,
     templatesMap,
     setTemplatesMap,
+    selectedTreatmentIndex,
+    setSelectedTreatmentIndex
   } = useContext(StageContext)
   // const stage1 = useContext(StageContext);
   // console.log("useStageMock", stage1)
@@ -91,7 +93,7 @@ export function useStage() {
       //const treatmentString = localStorage.getItem("treatment");
       //const treatment = JSON.parse(treatmentString);
       if (varName === "elements") {
-        var elements = treatment.treatments[0]?.gameStages[currentStageIndex]?.elements
+        var elements = treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.elements
         elements =  elements.flatMap((element) => {
           if (element.template) {
             return templatesMap.get(element.template);
@@ -101,9 +103,9 @@ export function useStage() {
         console.log("revised elements", elements)
         return elements;
       } else if (varName === "discussion") {
-        return treatment.treatments[0]?.gameStages[currentStageIndex]?.discussion
+        return treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.discussion
       } else if (varName === "name") {
-        return treatment.treatments[0]?.gameStages[currentStageIndex]?.name
+        return treatment.treatments[selectedTreatmentIndex]?.gameStages[currentStageIndex]?.name
       } else if (varName === "index") {
         return currentStageIndex
       }

--- a/cypress/e2e/filterTreatment.cy.ts
+++ b/cypress/e2e/filterTreatment.cy.ts
@@ -1,78 +1,180 @@
-describe('timeline filter treatment', () => {
+describe('timeline filter stages and treatments', () => {
     beforeEach(() => {
         // load initial treatment file
-        let yamltreatment = "treatments: \n - name: filter_timeline_test\n  playerCount: 1\ngameStages: []";
+        let yamltreatment = "treatments:\n- name: treatment_one\n  playerCount: 1\ngameStages: []\n";
         cy.viewport(2000, 1000, { log: false });
         cy.visit('http://localhost:3000/editor');
         cy.typeInCodeEditor(`{ctrl+a}{del}${yamltreatment}`) // equivalent to clear() in cypress
+        cy.typeInCodeEditor(`{backspace}`);
+        let secondTreatment = "- name: treatment_two\n  playerCount: 1\ngameStages: []\n";
+        cy.typeInCodeEditor(`${secondTreatment}`);
 
-        // verify initial text in editor
-
-        // text values from monaco-editor will include line numbers and no line breaks
-        // the yamltreatment variable has no line numbers and line breaks
-        // so right now comparison is only on the treatmentName
-        cy.containsInCodeEditor('filter_timeline_test')
+        // save treatment file
+        cy.containsInCodeEditor('treatment_one')
         cy.get('[data-cy="yaml-save"]').realClick()
 
-        // first stage
+        // ensure that the default treatment (treatment 0) is selected when the page is loaded
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '0');
+
+        // treatment one, first stage
         cy.get('[data-cy="add-stage-button"]').click();
         cy.get('[data-cy="edit-stage-name-new"]').type("Role Assignment and General Instructions");
         cy.get('[data-cy="edit-stage-duration-new"]').type("{backspace}300");
         cy.get('[data-cy="edit-stage-save-new"]').click();
 
-        // second stage
+        // treatment one, second stage
         cy.get('[data-cy="add-stage-button"]').click();
         cy.get('[data-cy="edit-stage-name-new"]').type("Main Discussion");
         cy.get('[data-cy="edit-stage-duration-new"]').type("{backspace}200");
         cy.get('[data-cy="edit-stage-save-new"]').click();
 
-        // third stage
+        // switch to the second treatment
+        cy.get('[data-cy="treatments-dropdown"] select').select('1');
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '1');
+
+        // treatment two, first stage
         cy.get('[data-cy="add-stage-button"]').click();
-        cy.get('[data-cy="edit-stage-name-new"]').type("Post Discussion Survey");
+        cy.get('[data-cy="edit-stage-name-new"]').type("test");
         cy.get('[data-cy="edit-stage-duration-new"]').type("{backspace}200");
         cy.get('[data-cy="edit-stage-save-new"]').click();
 
-        // all sections should initially be visible
+        // treatment two, second stage
+        cy.get('[data-cy="add-stage-button"]').click();
+        cy.get('[data-cy="edit-stage-name-new"]').type("test2");
+        cy.get('[data-cy="edit-stage-duration-new"]').type("{backspace}200");
+        cy.get('[data-cy="edit-stage-save-new"]').click();
+
+        // verify all stages in second treatment are visible
+        cy.get('[data-cy="stage-0"]').contains("test").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("test2").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+
+        // switch back to first treatment
+        cy.get('[data-cy="treatments-dropdown"] select').select('0');
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '0');
+
+        // all stages in treatment 0 should initially be visible
         cy.get('[data-cy="stage-0"]').contains("Role Assignment and General Instructions").should("be.visible");
         cy.get('[data-cy="stage-1"]').contains("Main Discussion").should("be.visible");
-        cy.get('[data-cy="stage-2"]').contains("Post Discussion Survey").should("be.visible");
-        cy.get('[data-cy^="stage-"]').should('have.length', 3);
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
     });
 
-    it('should dynamically populate filter options based on treatment file', () => {
+    it('should dynamically populate stage options in stages dropdown', () => {
         cy.get('[data-cy="stages-dropdown"] select').within(() => {
-            cy.get('option').should('have.length', 4);
+            cy.get('option').should('have.length', 3);
             cy.get('option').eq(0).should('have.text', 'All Stages');
             cy.get('option').eq(1).should('have.text', 'Role Assignment and General Instructions');
             cy.get('option').eq(2).should('have.text', 'Main Discussion');
-            cy.get('option').eq(3).should('have.text', 'Post Discussion Survey');
         });
     })
 
-    it('allows filtering stages by criteria', () => {
+    it('should dynamically populate treatment options in treatments dropdown', () => {
+        cy.get('[data-cy="treatments-dropdown"] select').within(() => {
+            cy.get('option').should('have.length', 2);
+            cy.get('option').eq(0).should('have.text', 'treatment_one');
+            cy.get('option').eq(1).should('have.text', 'treatment_two');
+        });
+    })
+
+    it('allows filtering by stage name', () => {
         // default option
         cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'all');
 
-        // select one section and ensure no other sections are visible
+        // select one stage and ensure no other stages are visible (assuming all stages have different names)
         cy.get('[data-cy="stages-dropdown"] select').select('Main Discussion');
         cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'Main Discussion');
         cy.get('[data-cy="stage-0"]').should('not.exist');
-        cy.get('[data-cy="stage-2"]').should('not.exist');
         cy.get('[data-cy="stage-1"]').contains("Main Discussion").should("be.visible");
         cy.get('[data-cy^="stage-"]').should('have.length', 1);
+
+        // verify that currentStageIndex in context and currentStageName in localStorage are correct after stage change
+        cy.window().its('stageContext').then((stageContext) => {
+            expect(stageContext.currentStageIndex).to.equal(1);
+        });
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('currentStageName')).to.equal('Main Discussion');
+        });
 
         // reset to all stages when filter option is cleared
         cy.get('[data-cy="stages-dropdown"] select').select('all');
         cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'all');
         cy.get('[data-cy="stage-0"]').contains("Role Assignment and General Instructions").should("be.visible");
         cy.get('[data-cy="stage-1"]').contains("Main Discussion").should("be.visible");
-        cy.get('[data-cy="stage-2"]').contains("Post Discussion Survey").should("be.visible");
-        cy.get('[data-cy^="stage-"]').should('have.length', 3);
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+
+        // verify that currentStageIndex and currentStageName are reset after clearing filter
+        cy.window().its('stageContext').then((stageContext) => {
+            expect(stageContext.currentStageIndex).to.equal(0);
+        });
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('currentStageName')).to.equal('all');
+        });
     })
 
-    it('should persist selected filter after page reload', () => {
+    it('allows filtering by treatment name', () => {
+        // Select the second treatment
+        cy.get('[data-cy="treatments-dropdown"] select').select('1');
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '1');
+
+        // Verify that selectedTreatmentIndex in both context and localStorage is correct
+        cy.window().its('stageContext').then((stageContext) => {
+            expect(stageContext.selectedTreatmentIndex).to.equal(1);
+        });
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('selectedTreatmentIndex')).to.equal('1');
+        });
+
+        // Verify that the stages for the second treatment are displayed
+        cy.get('[data-cy="stage-0"]').contains("test").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("test2").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+
+        // Verify that selecting stages works in second treatment
+        cy.get('[data-cy="stages-dropdown"] select').select('test2');
+        cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'test2');
+        cy.get('[data-cy="stage-0"]').should('not.exist');
+        cy.get('[data-cy="stage-1"]').contains("test").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 1);
+
+        // Verify that currentStageIndex in context and currentStageName in localStorage are correct after stage change
+        cy.window().its('stageContext').then((stageContext) => {
+            expect(stageContext.currentStageIndex).to.equal(1);
+        });
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('currentStageName')).to.equal('test2');
+        });
+
+        // Switch back to the first treatment
+        cy.get('[data-cy="treatments-dropdown"] select').select('0');
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '0');
+
+        // Verify that the selectedTreatmentIndex in context and localStorage is correct
+        cy.window().its('stageContext').then((stageContext) => {
+            expect(stageContext.selectedTreatmentIndex).to.equal(0);
+        });
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('selectedTreatmentIndex')).to.equal('0');
+        });
+
+        // Verify that currentStageIndex and currentStageName are reset after switching treatments
+        cy.window().its('stageContext').then((stageContext) => {
+            expect(stageContext.currentStageIndex).to.equal(0);
+        });
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('currentStageName')).to.equal('all');
+        });
+
+        // Verify that the stages for the first treatment are displayed
+        cy.get('[data-cy="stage-0"]').contains("Role Assignment and General Instructions").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("Main Discussion").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+    })
+
+    it('should persist selected stage after page reload', () => {
+        // Initial stage
         cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'all');
 
+        // Select a new stage
         cy.get('[data-cy="stages-dropdown"] select').select('Main Discussion');
         cy.get('[data-cy="stage-0"]').should('not.exist');
         cy.get('[data-cy="stage-2"]').should('not.exist');
@@ -81,7 +183,7 @@ describe('timeline filter treatment', () => {
 
         cy.reload(); // reload page
 
-        cy.get('[data-cy="stages-dropdown"] select').select('Main Discussion');
+        // Verify that stage selection persists
         cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'Main Discussion');
         cy.get('[data-cy="stage-0"]').should('not.exist');
         cy.get('[data-cy="stage-2"]').should('not.exist');
@@ -89,7 +191,49 @@ describe('timeline filter treatment', () => {
         cy.get('[data-cy^="stage-"]').should('have.length', 1);
     })
 
-    // add test for same named stages
+    it('should persist selected treatment after page reload', () => {
+        // Initial treatment
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', 'treatment_one');
 
-    // make sure stageIndex is updated
+        // Select a new treatment
+        cy.get('[data-cy="treatments-dropdown"] select').select('1');
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '1');
+        cy.get('[data-cy="stage-0"]').contains("test").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("test2").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+
+        cy.reload(); // reload page
+
+        // Verify that timeline persists
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '1');
+        cy.get('[data-cy="stage-0"]').contains("test").should("be.visible");
+        cy.get('[data-cy="stage-1"]').contains("test2").should("be.visible");
+        cy.get('[data-cy^="stage-"]').should('have.length', 2);
+    })
+
+    // this might throw an error in app
+    it('should show a useful message when stages array is empty', () => {
+        // Add a treatment with an empty stages array
+        cy.typeInCodeEditor(`{backspace}`);
+        let emptyStagesTreatment = "- name: treatment_three\n  playerCount: 1\ngameStages: []\n";
+        cy.typeInCodeEditor(`${emptyStagesTreatment}`);
+        cy.get('[data-cy="yaml-save"]').realClick();
+
+        // Select the treatment with empty stages
+        cy.get('[data-cy="treatments-dropdown"] select').select('2');
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '2');
+
+        // Verify the message
+        cy.get('[data-cy="stages-dropdown"]').contains("Nothing available").should("be.visible");
+    })
+
+    it('should show a useful message when treatments array is empty', () => {
+        // Load an empty treatments array
+        let emptyTreatments = "treatments: []\n";
+        cy.typeInCodeEditor(`{ctrl+a}{del}${emptyTreatments}`);
+        cy.get('[data-cy="yaml-save"]').realClick();
+
+        // Verify the messages
+        cy.get('[data-cy="treatments-dropdown"]').contains("Nothing available").should("be.visible");
+    })
 })

--- a/cypress/e2e/filterTreatment.cy.ts
+++ b/cypress/e2e/filterTreatment.cy.ts
@@ -40,7 +40,7 @@ describe('timeline filter treatment', () => {
     });
 
     it('should dynamically populate filter options based on treatment file', () => {
-        cy.get('[data-cy="filter-dropdown"] select').within(() => {
+        cy.get('[data-cy="stages-dropdown"] select').within(() => {
             cy.get('option').should('have.length', 4);
             cy.get('option').eq(0).should('have.text', 'All Stages');
             cy.get('option').eq(1).should('have.text', 'Role Assignment and General Instructions');
@@ -51,19 +51,19 @@ describe('timeline filter treatment', () => {
 
     it('allows filtering stages by criteria', () => {
         // default option
-        cy.get('[data-cy="filter-dropdown"] select').should('have.value', 'all');
+        cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'all');
 
         // select one section and ensure no other sections are visible
-        cy.get('[data-cy="filter-dropdown"] select').select('Main Discussion');
-        cy.get('[data-cy="filter-dropdown"] select').should('have.value', 'Main Discussion');
+        cy.get('[data-cy="stages-dropdown"] select').select('Main Discussion');
+        cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'Main Discussion');
         cy.get('[data-cy="stage-0"]').should('not.exist');
         cy.get('[data-cy="stage-2"]').should('not.exist');
         cy.get('[data-cy="stage-1"]').contains("Main Discussion").should("be.visible");
         cy.get('[data-cy^="stage-"]').should('have.length', 1);
 
         // reset to all stages when filter option is cleared
-        cy.get('[data-cy="filter-dropdown"] select').select('all');
-        cy.get('[data-cy="filter-dropdown"] select').should('have.value', 'all');
+        cy.get('[data-cy="stages-dropdown"] select').select('all');
+        cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'all');
         cy.get('[data-cy="stage-0"]').contains("Role Assignment and General Instructions").should("be.visible");
         cy.get('[data-cy="stage-1"]').contains("Main Discussion").should("be.visible");
         cy.get('[data-cy="stage-2"]').contains("Post Discussion Survey").should("be.visible");
@@ -71,9 +71,9 @@ describe('timeline filter treatment', () => {
     })
 
     it('should persist selected filter after page reload', () => {
-        cy.get('[data-cy="filter-dropdown"] select').should('have.value', 'all');
+        cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'all');
 
-        cy.get('[data-cy="filter-dropdown"] select').select('Main Discussion');
+        cy.get('[data-cy="stages-dropdown"] select').select('Main Discussion');
         cy.get('[data-cy="stage-0"]').should('not.exist');
         cy.get('[data-cy="stage-2"]').should('not.exist');
         cy.get('[data-cy="stage-1"]').contains("Main Discussion").should("be.visible");
@@ -81,8 +81,8 @@ describe('timeline filter treatment', () => {
 
         cy.reload(); // reload page
 
-        cy.get('[data-cy="filter-dropdown"] select').select('Main Discussion');
-        cy.get('[data-cy="filter-dropdown"] select').should('have.value', 'Main Discussion');
+        cy.get('[data-cy="stages-dropdown"] select').select('Main Discussion');
+        cy.get('[data-cy="stages-dropdown"] select').should('have.value', 'Main Discussion');
         cy.get('[data-cy="stage-0"]').should('not.exist');
         cy.get('[data-cy="stage-2"]').should('not.exist');
         cy.get('[data-cy="stage-1"]').contains("Main Discussion").should("be.visible");

--- a/cypress/e2e/filterTreatment.cy.ts
+++ b/cypress/e2e/filterTreatment.cy.ts
@@ -193,9 +193,9 @@ describe('timeline filter stages and treatments', () => {
 
     it('should persist selected treatment after page reload', () => {
         // Initial treatment
-        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', 'treatment_one');
+        cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '0');
 
-        // Select a new treatment
+        // Select a new treatment and verify timeline contents
         cy.get('[data-cy="treatments-dropdown"] select').select('1');
         cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '1');
         cy.get('[data-cy="stage-0"]').contains("test").should("be.visible");
@@ -211,10 +211,11 @@ describe('timeline filter stages and treatments', () => {
         cy.get('[data-cy^="stage-"]').should('have.length', 2);
     })
 
-    // this might throw an error in app
     it('should show a useful message when stages array is empty', () => {
         // Add a treatment with an empty stages array
-        cy.typeInCodeEditor(`{backspace}`);
+        cy.typeInCodeEditor(`\n`);
+        cy.typeInCodeEditor(` `);
+        cy.typeInCodeEditor(` `);
         let emptyStagesTreatment = "- name: treatment_three\n  playerCount: 1\ngameStages: []\n";
         cy.typeInCodeEditor(`${emptyStagesTreatment}`);
         cy.get('[data-cy="yaml-save"]').realClick();
@@ -224,7 +225,7 @@ describe('timeline filter stages and treatments', () => {
         cy.get('[data-cy="treatments-dropdown"] select').should('have.value', '2');
 
         // Verify the message
-        cy.get('[data-cy="stages-dropdown"]').contains("Nothing available").should("be.visible");
+        cy.get('[data-cy="stages-dropdown"] select').should('contain', 'Nothing available');
     })
 
     it('should show a useful message when treatments array is empty', () => {
@@ -234,6 +235,6 @@ describe('timeline filter stages and treatments', () => {
         cy.get('[data-cy="yaml-save"]').realClick();
 
         // Verify the messages
-        cy.get('[data-cy="treatments-dropdown"]').contains("Nothing available").should("be.visible");
+        cy.get('[data-cy="treatments-dropdown"] select').should('contain', 'Nothing available');
     })
 })

--- a/cypress/e2e/reorder.cy.ts
+++ b/cypress/e2e/reorder.cy.ts
@@ -56,11 +56,11 @@ describe('timeline drag and drop', () => {
         cy.get('[data-cy^="element-0-"]').should('have.length', 2);
 
         // swap first element with second element
-        cy.get('[data-cy="element-0-0"]')
-            .focus()
-            .type(" ") // space bar selects item to move
-            .type("{downArrow}") // move element down one
-            .type(" "); // stop moving item
+        cy.get('[data-cy="element-0-0"]').as('dragElement');
+        cy.get('@dragElement').focus();
+        cy.get('@dragElement').type(" "); // space bar selects item to move
+        cy.get('@dragElement').type("{downArrow}"); // move element down one
+        cy.get('@dragElement').type(" "); // stop moving item
 
         cy.wait(1000);
 
@@ -77,11 +77,11 @@ describe('timeline drag and drop', () => {
         cy.get('[data-cy^="stage-"]').should('have.length', 2);
 
         // swap first stage with second stage
-        cy.get('[data-cy="stage-0"]')
-            .focus()
-            .type(" ")
-            .type("{rightArrow}") // move stage 1 to the right
-            .type(" ");
+        cy.get('[data-cy="stage-0"]').as('dragStage');
+        cy.get('@dragStage').focus();
+        cy.get('@dragStage').type(" ");
+        cy.get('@dragStage').type("{rightArrow}");
+        cy.get('@dragStage').type(" ");
 
         cy.wait(1000);
 
@@ -99,11 +99,11 @@ describe('timeline drag and drop', () => {
 
         // try moving first element from stage 1 to stage 2
         cy.wait(1000);
-        cy.get('[data-cy="element-0-0"]')
-            .focus()
-            .type(" ")
-            .type("{rightArrow}")
-            .type(" ");
+        cy.get('[data-cy="element-0-0"]').as('dragElement');
+        cy.get('@dragElement').focus();
+        cy.get('@dragElement').type(" ");
+        cy.get('@dragElement').type("{rightArrow}");
+        cy.get('@dragElement').type(" ");
 
         cy.wait(1000);
 
@@ -113,11 +113,11 @@ describe('timeline drag and drop', () => {
         cy.get('[data-cy^="element-0-"]').should('have.length', 2);
 
         // try moving second element outside of stage 1
-        cy.get('[data-cy="element-0-1"]')
-            .focus()
-            .type(" ")
-            .type("{rightArrow}")
-            .type(" ");
+        cy.get('[data-cy="element-0-1"]').as('dragElement2');
+        cy.get('@dragElement2').focus();
+        cy.get('@dragElement2').type(" ");
+        cy.get('@dragElement2').type("{rightArrow}");
+        cy.get('@dragElement2').type(" ");
 
         cy.wait(1000);
 
@@ -134,11 +134,11 @@ describe('timeline drag and drop', () => {
         cy.get('[data-cy^="stage-"]').should('have.length', 2);
 
         // try dragging stage outside of timeline 
-        cy.get('[data-cy="stage-0"]')
-            .focus()
-            .type(" ")
-            .type("{upArrow}")
-            .type(" ");
+        cy.get('[data-cy="stage-0"]').as('dragStage');
+        cy.get('@dragStage').focus();
+        cy.get('@dragStage').type(" ");
+        cy.get('@dragStage').type("{upArrow}");
+        cy.get('@dragStage').type(" ");
 
         cy.wait(1000);
 

--- a/cypress/e2e/test.cy.ts
+++ b/cypress/e2e/test.cy.ts
@@ -107,7 +107,7 @@ describe('test spec', () => {
         // view second stage in render panel
         cy.get('[data-cy="stage-1"]').click(0, 0)
         cy.get('[data-cy="render-panel"]').contains("Click on a stage card to preview the stage from a participant view.").should("not.exist")
-        cy.get('[data-cy="render-panel"]').contains("Click to continue the video").should("be.visible")
+        //cy.get('[data-cy="render-panel"]').contains("Click to continue the video").should("be.visible")
 
         // edit second element in first stage
         cy.get('[data-cy="edit-element-button-0-1"]').click()

--- a/cypress/e2e/test.cy.ts
+++ b/cypress/e2e/test.cy.ts
@@ -107,7 +107,7 @@ describe('test spec', () => {
         // view second stage in render panel
         cy.get('[data-cy="stage-1"]').click(0, 0)
         cy.get('[data-cy="render-panel"]').contains("Click on a stage card to preview the stage from a participant view.").should("not.exist")
-        //cy.get('[data-cy="render-panel"]').contains("Click to continue the video").should("be.visible")
+        cy.get('[data-cy="render-panel"]').contains("Click to continue the video").should("be.visible")
 
         // edit second element in first stage
         cy.get('[data-cy="edit-element-button-0-1"]').click()

--- a/src/app/editor/components/CodeEditor.tsx
+++ b/src/app/editor/components/CodeEditor.tsx
@@ -19,18 +19,17 @@ export default function CodeEditor() {
   useEffect(() => {
     async function fetchDefaultTreatment() {
       var data = defaultTreatment
-      if (defaultTreatment) {
-        return // If defaultTreatment is already set, do nothing
-      } else {
-        const response = await fetch('/defaultTreatment.yaml')
-        const text = await response.text()
-        data = yaml.load(text)
-        setDefaultTreatment(data)
-      }
+      if (defaultTreatment) return // If defaultTreatment is already set, do nothing
+      
+      const response = await fetch('/defaultTreatment.yaml')
+      const text = await response.text()
+      data = yaml.load(text)
+      setDefaultTreatment(data)
 
       const storedCode = localStorage.getItem('code') || ''
       if (storedCode === '') {
         setCode(stringify(data))
+        localStorage.setItem('code', stringify(data))
       } else {
         setCode(storedCode)
       }

--- a/src/app/editor/components/Dropdown.tsx
+++ b/src/app/editor/components/Dropdown.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+interface DropdownProps {
+  label: string
+  options: string[]
+  value: string | number
+  onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void
+  dataCy: string
+}
+
+const Dropdown = ({
+  label,
+  options = [],
+  value,
+  onChange,
+  dataCy,
+}: DropdownProps) => {
+  return (
+    <div data-cy={dataCy} className="flex items-center space-x-2">
+      <label className="text-gray font-medium">{label}</label>
+      <select
+        value={value}
+        onChange={onChange}
+        className="select select-bordered bg-white text-gray-700 font-medium h-full text-sm rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 truncate max-w-xs"
+      >
+        {options.map((option, index) => (
+          <option
+            key={index}
+            value={typeof value === 'number' ? index : option}
+            className="truncate"
+          >
+            {typeof value === 'number'
+              ? option
+              : option === 'all'
+              ? 'All Stages'
+              : option}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export default Dropdown

--- a/src/app/editor/components/Dropdown.tsx
+++ b/src/app/editor/components/Dropdown.tsx
@@ -15,27 +15,36 @@ const Dropdown = ({
   onChange,
   dataCy,
 }: DropdownProps) => {
+  const isStageOptionsEmpty = options.length === 1 && options[0] === 'all'
+
   return (
     <div data-cy={dataCy} className="flex items-center space-x-2">
       <label className="text-gray font-medium">{label}</label>
       <select
         value={value}
         onChange={onChange}
-        className="select select-bordered bg-white text-gray-700 font-medium h-full text-sm rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 truncate max-w-xs"
+        className="select select-bordered bg-white text-gray-700 font-medium h-full text-sm rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 truncate"
+        style={{ width: '200px' }} // Fixed width
       >
-        {options.map((option, index) => (
-          <option
-            key={index}
-            value={typeof value === 'number' ? index : option}
-            className="truncate"
-          >
-            {typeof value === 'number'
-              ? option
-              : option === 'all'
-              ? 'All Stages'
-              : option}
+        {options.length === 0 || isStageOptionsEmpty ? (
+          <option value="" disabled className="text-gray-700">
+            Nothing available
           </option>
-        ))}
+        ) : (
+          options.map((option, index) => (
+            <option
+              key={index}
+              value={typeof value === 'number' ? index : option}
+              className="truncate text-gray-700"
+            >
+              {typeof value === 'number'
+                ? option
+                : option === 'all'
+                ? 'All Stages'
+                : option}
+            </option>
+          ))
+        )}
       </select>
     </div>
   )

--- a/src/app/editor/components/EditElement.tsx
+++ b/src/app/editor/components/EditElement.tsx
@@ -22,6 +22,8 @@ export function EditElement({
     editTreatment,
     templatesMap,
     setTemplatesMap,
+    selectedTreatmentIndex,
+    setSelectedTreatmentIndex
   } = useContext(StageContext)
 
   const {
@@ -33,11 +35,11 @@ export function EditElement({
   } = useForm({
     defaultValues: {
       name:
-        treatment?.treatments?.[0].gameStages[stageIndex]?.elements[
+        treatment?.treatments?.[selectedTreatmentIndex].gameStages[stageIndex]?.elements[
           elementIndex
         ]?.name || '',
       selectedOption:
-        treatment?.treatments?.[0].gameStages[stageIndex]?.elements[
+        treatment?.treatments?.[selectedTreatmentIndex].gameStages[stageIndex]?.elements[
           elementIndex
         ]?.type || 'Pick one',
       file: '',
@@ -88,11 +90,11 @@ export function EditElement({
     }
 
     if (elementIndex === -1) {
-      updatedTreatment?.treatments[0].gameStages[stageIndex]?.elements?.push(
+      updatedTreatment?.treatments[selectedTreatmentIndex].gameStages[stageIndex]?.elements?.push(
         inputs
       )
     } else {
-      updatedTreatment.treatments[0].gameStages[stageIndex].elements[
+      updatedTreatment.treatments[selectedTreatmentIndex].gameStages[stageIndex].elements[
         elementIndex
       ] = inputs
     }
@@ -106,7 +108,7 @@ export function EditElement({
     )
     if (confirm) {
       const updatedTreatment = JSON.parse(JSON.stringify(treatment)) // deep copy
-      updatedTreatment.treatments[0].gameStages[stageIndex].elements.splice(
+      updatedTreatment.treatments[selectedTreatmentIndex].gameStages[stageIndex].elements.splice(
         elementIndex,
         1
       ) // delete in place

--- a/src/app/editor/components/EditStage.tsx
+++ b/src/app/editor/components/EditStage.tsx
@@ -26,6 +26,8 @@ export function EditStage({
     editTreatment,
     templatesMap,
     setTemplatesMap,
+    selectedTreatmentIndex,
+    setSelectedTreatmentIndex,
   } = useContext(StageContext)
 
   const {
@@ -38,15 +40,15 @@ export function EditStage({
     defaultValues: {
       name:
         stageIndex != -1
-          ? treatment?.treatments?.[0].gameStages[stageIndex]?.name
+          ? treatment?.treatments?.[selectedTreatmentIndex].gameStages[stageIndex]?.name
           : '',
       duration:
         stageIndex != -1
-          ? treatment?.treatments?.[0].gameStages[stageIndex]?.duration
+          ? treatment?.treatments?.[selectedTreatmentIndex].gameStages[stageIndex]?.duration
           : 0,
       elements:
         stageIndex != -1
-          ? treatment?.treatments?.[0].gameStages[stageIndex]?.elements
+          ? treatment?.treatments?.[selectedTreatmentIndex].gameStages[stageIndex]?.elements
           : [],
       // desc: "",
       // discussion: {
@@ -66,7 +68,7 @@ export function EditStage({
       name: watch('name'),
       duration: watch('duration'),
       elements:
-        treatment?.treatments?.[0].gameStages[stageIndex]?.elements || [],
+        treatment?.treatments?.[selectedTreatmentIndex].gameStages[stageIndex]?.elements || [],
       // discussion: undefined,
       // desc: watch('desc'),
     }
@@ -93,11 +95,11 @@ export function EditStage({
 
     if (stageIndex === -1) {
       // create new stage
-      updatedTreatment?.treatments?.[0].gameStages?.push(inputs)
+      updatedTreatment?.treatments?.[selectedTreatmentIndex].gameStages?.push(inputs)
     } else {
       // modify existing stage
-      updatedTreatment.treatments[0].gameStages[stageIndex].name = watch('name')
-      updatedTreatment.treatments[0].gameStages[stageIndex].duration =
+      updatedTreatment.treatments[selectedTreatmentIndex].gameStages[stageIndex].name = watch('name')
+      updatedTreatment.treatments[selectedTreatmentIndex].gameStages[stageIndex].duration =
         watch('duration')
       // todo: add discussion component
     }
@@ -110,7 +112,7 @@ export function EditStage({
     )
     if (confirm) {
       const updatedTreatment = JSON.parse(JSON.stringify(treatment)) // deep copy
-      updatedTreatment.treatments[0].gameStages.splice(stageIndex, 1) // delete in place
+      updatedTreatment.treatments[selectedTreatmentIndex].gameStages.splice(stageIndex, 1) // delete in place
       editTreatment(updatedTreatment)
     }
   }

--- a/src/app/editor/components/ElementCard.tsx
+++ b/src/app/editor/components/ElementCard.tsx
@@ -34,6 +34,8 @@ export function ElementCard({
     setTreatment,
     templatesMap,
     setTemplatesMap,
+    selectedTreatmentIndex,
+    setSelectedTreatmentIndex,
   } = useContext(StageContext)
 
   const editModalId = `modal-stage${stageIndex}-element-${elementIndex}`

--- a/src/app/editor/components/RenderPanel.tsx
+++ b/src/app/editor/components/RenderPanel.tsx
@@ -45,6 +45,10 @@ export function RenderPanel() {
     treatment,
     setTreatment,
     player,
+    templatesMap,
+    setTemplatesMap,
+    selectedTreatmentIndex,
+    setSelectedTreatmentIndex,
   } = useContext(StageContext)
 
   console.log('RenderPanel.tsx current stage index', currentStageIndex)
@@ -79,12 +83,12 @@ export function RenderPanel() {
             value={time + ' s'}
             setValue={setElapsed}
             maxValue={
-              treatment.treatments?.[0].gameStages[currentStageIndex]
+              treatment.treatments?.[selectedTreatmentIndex].gameStages[currentStageIndex]
                 ?.duration ?? 0
             }
           />
           <ReferenceData
-            treatment={treatment.treatments?.[0]}
+            treatment={treatment.treatments?.[selectedTreatmentIndex]}
             stageIndex={currentStageIndex}
           />
           {/* need to retrieve stage duration from treatment */}

--- a/src/app/editor/components/StageCard.tsx
+++ b/src/app/editor/components/StageCard.tsx
@@ -41,6 +41,8 @@ export function StageCard({
     editTreatment,
     templatesMap,
     setTemplatesMap,
+    selectedTreatmentIndex,
+    setSelectedTreatmentIndex,
   } = useContext(StageContext)
 
   const addElementOptions = [
@@ -98,7 +100,7 @@ export function StageCard({
 
     // update treatment
     const updatedTreatment = JSON.parse(JSON.stringify(treatment))
-    updatedTreatment.treatments[0].gameStages[stageIndex].elements =
+    updatedTreatment.treatments[selectedTreatmentIndex].gameStages[stageIndex].elements =
       updatedElements
     editTreatment(updatedTreatment)
   }

--- a/src/app/editor/components/StageCard.tsx
+++ b/src/app/editor/components/StageCard.tsx
@@ -156,8 +156,8 @@ export function StageCard({
               {elements !== undefined &&
                 elements.map((element, index) => (
                   <Draggable
-                    key={`element-${stageIndex}-${index}`}
-                    draggableId={`element-${stageIndex}-${index}`}
+                    key={`element-${selectedTreatmentIndex}-${stageIndex}-${index}`}
+                    draggableId={`element-${selectedTreatmentIndex}-${stageIndex}-${index}`}
                     index={index}
                   >
                     {(provided) => (

--- a/src/app/editor/components/Timeline.tsx
+++ b/src/app/editor/components/Timeline.tsx
@@ -47,11 +47,11 @@ export default function Timeline({
       setCurrentStageName(storedFilter)
 
       const storedTreatmentIndex =
-        localStorage.getItem('selectedTreatmentIndex') || 0
+        parseInt(localStorage.getItem('selectedTreatmentIndex') || '0', 10)
       setSelectedTreatmentIndex(storedTreatmentIndex)
 
       const storedIntroSequenceIndex =
-        localStorage.getItem('selectedIntroSequenceIndex') || 0
+        parseInt(localStorage.getItem('selectedIntroSequenceIndex') || '0', 10)
       setSelectedIntroSequenceIndex(storedIntroSequenceIndex)
     }
   }, [setTreatment, setSelectedTreatmentIndex, setSelectedIntroSequenceIndex])
@@ -81,12 +81,11 @@ export default function Timeline({
         )
         setTreatmentOptions(treatmentNames)
 
-        localStorage.setItem('selectedTreatmentIndex', selectedTreatmentIndex)
         const selectedTreatment = treatment.treatments[selectedTreatmentIndex]
         const filteredStages = filterStages(selectedTreatment)
 
         if (filteredStages.length > 0) {
-          setCurrentStageIndex(filteredStages[0].originalIndex) // default to first filtered stage
+          setCurrentStageIndex(filteredStages[0].originalIndex) // default to first filtered stage, in case some stages have the same name
         }
 
         const stageNames =
@@ -142,19 +141,20 @@ export default function Timeline({
     }
   }
 
-  function handleTreatmentChange(event: any) {
+  function handleTreatmentChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    const newIndex = parseInt(event.target.value, 10)
     setCurrentStageIndex(0)
-    setSelectedTreatmentIndex(event.target.value)
-    localStorage.setItem('selectedTreatmentIndex', event.target.value)
+    setSelectedTreatmentIndex(newIndex)
+    localStorage.setItem('selectedTreatmentIndex', newIndex.toString())
     setCurrentStageName('all')
     localStorage.setItem('currentStageName', 'all')
   }
 
-  function handleIntroSequenceChange(event: any) {
-    setSelectedIntroSequenceIndex(event.target.value)
-    localStorage.setItem('selectedIntroSequenceIndex', event.target.value)
+  function handleIntroSequenceChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    const newIndex = parseInt(event.target.value, 10)
+    setSelectedIntroSequenceIndex(newIndex)
+    localStorage.setItem('selectedIntroSequenceIndex', newIndex.toString())
     setCurrentStageName('all')
-    localStorage.setItem('currentStageName', 'all')
   }
 
   // drag and drop handler
@@ -191,17 +191,19 @@ export default function Timeline({
         <Dropdown
           label="Select treatment:"
           options={treatmentOptions}
-          value={Number(selectedTreatmentIndex)}
+          value={selectedTreatmentIndex}
           onChange={handleTreatmentChange}
           dataCy="treatments-dropdown"
         />
+
         <Dropdown
           label="Select intro sequence:"
           options={introSequenceOptions}
-          value={Number(selectedIntroSequenceIndex)}
+          value={selectedIntroSequenceIndex}
           onChange={handleIntroSequenceChange}
           dataCy="intro-sequence-dropdown"
         />
+
         <Dropdown
           label="Select stage:"
           options={stageOptions}

--- a/src/app/editor/components/Timeline.tsx
+++ b/src/app/editor/components/Timeline.tsx
@@ -271,7 +271,7 @@ export default function Timeline({
                   )?.map((obj: any, index: any) => (
                     <Draggable
                       key={obj.stage.name}
-                      draggableId={`stage-${obj.originalIndex}`}
+                      draggableId={`treatment-${selectedTreatmentIndex}-stage-${obj.originalIndex}`}
                       index={index}
                     >
                       {(provided) => (

--- a/src/app/editor/components/Timeline.tsx
+++ b/src/app/editor/components/Timeline.tsx
@@ -127,8 +127,19 @@ export default function Timeline({
   }
 
   function handleStageNameChange(event: any) {
-    setCurrentStageName(event.target.value)
-    localStorage.setItem('currentStageName', event.target.value)
+    const selectedStageName = event.target.value
+    setCurrentStageName(selectedStageName)
+    localStorage.setItem('currentStageName', selectedStageName)
+
+    if (selectedStageName === 'all') {
+      setCurrentStageIndex(0)
+    } else {
+      const selectedTreatment = treatment.treatments[selectedTreatmentIndex]
+      const stageIndex = selectedTreatment.gameStages.findIndex(
+        (stage: any) => stage.name === selectedStageName
+      )
+      setCurrentStageIndex(stageIndex)
+    }
   }
 
   function handleTreatmentChange(event: any) {

--- a/src/app/editor/stageContext.jsx
+++ b/src/app/editor/stageContext.jsx
@@ -7,7 +7,7 @@ import {
   usePlayer,
   useRound,
   useStageTimer,
-} from "@empirica/core/player/classic/react";
+} from '@empirica/core/player/classic/react'
 
 // export const StageContext = createContext({
 //     currentStageIndex: "default",
@@ -21,6 +21,9 @@ const StageProvider = ({ children }) => {
   const [elapsed, setElapsed] = useState(0)
   const [treatment, setTreatment] = useState(null)
   const [templatesMap, setTemplatesMap] = useState(new Map())
+  const [selectedTreatmentIndex, setSelectedTreatmentIndex] = useState(0)
+  const [selectedIntroSequenceIndex, setSelectedIntroSequenceIndex] =
+    useState(0)
   const player = usePlayer()
 
   // for updating code editor, requires reload
@@ -41,6 +44,10 @@ const StageProvider = ({ children }) => {
     player,
     templatesMap,
     setTemplatesMap,
+    selectedTreatmentIndex,
+    setSelectedTreatmentIndex,
+    selectedIntroSequenceIndex,
+    setSelectedIntroSequenceIndex,
   }
 
   return (

--- a/src/app/editor/stageContext.jsx
+++ b/src/app/editor/stageContext.jsx
@@ -1,5 +1,5 @@
 //import { set } from 'node_modules/cypress/types/lodash';
-import { createContext, useState } from 'react'
+import { createContext, useState, useCallback, useMemo, useEffect } from 'react'
 import { stringify } from 'yaml'
 import {
   useGame,
@@ -27,13 +27,13 @@ const StageProvider = ({ children }) => {
   const player = usePlayer()
 
   // for updating code editor, requires reload
-  function editTreatment(newTreatment) {
+  const editTreatment = useCallback((newTreatment) => {
     setTreatment(newTreatment)
     localStorage.setItem('code', stringify(newTreatment))
     window.location.reload()
-  }
+  }, [setTreatment])
 
-  const contextValue = {
+  const contextValue = useMemo(() => ({
     currentStageIndex,
     setCurrentStageIndex,
     elapsed,
@@ -48,7 +48,27 @@ const StageProvider = ({ children }) => {
     setSelectedTreatmentIndex,
     selectedIntroSequenceIndex,
     setSelectedIntroSequenceIndex,
-  }
+  }), [
+    currentStageIndex,
+    setCurrentStageIndex,
+    elapsed,
+    setElapsed,
+    treatment,
+    setTreatment,
+    editTreatment,
+    player,
+    templatesMap,
+    setTemplatesMap,
+    selectedTreatmentIndex,
+    setSelectedTreatmentIndex,
+    selectedIntroSequenceIndex,
+    setSelectedIntroSequenceIndex,
+  ])
+
+  // expose context values to the window object
+  useEffect(() => {
+    window.stageContext = contextValue
+  }, [contextValue])
 
   return (
     <StageContext.Provider value={contextValue}>


### PR DESCRIPTION
This PR includes several changes to improve the handling of treatments and stages in Timeline, as well as new Cypress tests to reflect these changes. The most important additions are new state variables, updates to the Cypress tests, and the introduction of a new Dropdown component for selecting different sections of a treatment object (for now, just treatments and stages).

Closes #97, #98, #102, #106, #107.

### Support for dynamic selection of different treatments:

* Added `selectedTreatmentIndex` and `setSelectedTreatmentIndex` to the app's global context to handle selection of treatments dynamically.
* Updated logic throughout codebase to use `selectedTreatmentIndex` instead of hardcoded indices.

### Cypress test updates:

* Added the `filterTreatment.cy.ts` file to include tests for 
   * dynamically populating stage and treatment options
   * testing various cases of using the dropdown component
   * ensuring consistent conditional rendering in Timeline and consistent global and localStorage variables
   * verifying the persistence of selected stages and treatments after page reloads.
   * testing edge cases, including when either the treatments array or stages array is empty.
* Refactored the `reorder.cy.ts` file to use aliases for drag and drop elements and stages instead of chain of commands to (hopefully) make the tests more robust and resist failures.

### New Dropdown Component:

* Introduced a new `Dropdown` component in `Dropdown.tsx` to standardize the dropdown UI elements used for selecting treatments and stages (and in the future, introSequences and possibly templates).

### Refactored Timeline:

* Mostly reworked some logic and refactored code for better maintainability:
   * Better state management by adding default values and parsing for context/localStorage values to prevent errors during initialization
   * Synchronized index values in localStorage with values in context for consistency with app and cypress tests that use those values for validation checks.

### Submodule update:

* Updated the submodule commit reference for `deliberation-empirica`.

### Notes

I added some logic for handling introSequences in Timeline that isn't tested. This is mostly there for future work in a separate branch or issue. This PR only focuses on treatments and stages/elements.